### PR TITLE
Add mobile search and sticky aisle nav

### DIFF
--- a/app/frontend/src/App.jsx
+++ b/app/frontend/src/App.jsx
@@ -139,10 +139,19 @@ function App() {
   function selectFilter(aisleId) {
     setFilterOption(aisleId);
     setSearchQuery('');
-    if (listRef.current) {
+    if (isMobile) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    } else if (listRef.current) {
       listRef.current.scrollTop = 0;
     }
   }
+
+  useEffect(() => {
+    if (!isMobile) return;
+    const onWindowScroll = () => setScrolled(window.scrollY > 10);
+    window.addEventListener('scroll', onWindowScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onWindowScroll);
+  }, [isMobile]);
 
   const lastScrollTop = useRef(0);
 
@@ -172,7 +181,7 @@ function App() {
   }, [cartCount]);
 
   return (
-    <div className="flex flex-col h-[100dvh] overflow-y-hidden bg-brand-cream">
+    <div className="flex flex-col md:h-[100dvh] md:overflow-y-hidden bg-brand-cream">
       <Newsletter show={showNewsletter && !isMobile} onCloseButtonClick={handleClickNewsletter} />
       <Checkout show={showCheckout && !isMobile} updateShow={handleClickCheckout} productsList={products} handleDeleteCart={deleteCart} onCloseButtonClick={handleClickCheckout} handleConfirmation={handleShowConfirmation} handleError={handleshowCheckoutError} updateCheckoutResponse={setCheckoutResponse} />
       <MobileNewsletterSheet show={showNewsletter && isMobile} onClose={handleClickNewsletter} />
@@ -180,7 +189,7 @@ function App() {
       <AlertModal show={showConfirmation} onCloseButtonClick={handleShowConfirmation} message={checkoutResponse} />
       <AlertModal show={showCheckoutError} onCloseButtonClick={handleshowCheckoutError} message={checkoutResponse} />
 
-      <header className={`flex flex-grow-0 bg-white border-b border-brand-border px-4 md:px-8 items-center z-10 transition-all duration-300 ${scrolled ? 'h-[48px]' : 'h-[76px]'}`}>
+      <header className={`sticky top-0 flex flex-grow-0 bg-white border-b border-brand-border px-4 md:px-8 items-center z-10 transition-all duration-300 ${scrolled ? 'h-[48px]' : 'h-[76px]'}`}>
         {/* Desktop header */}
         <div className="hidden md:flex flex-auto w-full  max-w-[1200px] mx-auto px-4 md:px-8 gap-0 md:gap-7 overflow-hidden">
           <div className="hidden md:flex items-center gap-[18px] flex-shrink-0">
@@ -205,9 +214,9 @@ function App() {
       </header>
 
       {/* Mobile category select */}
-      <MobileAislesNav categories={categories} activeFilter={filterOption} onSelect={selectFilter} />
+      <MobileAislesNav categories={categories} activeFilter={filterOption} onSelect={selectFilter} searchQuery={searchQuery} onSearch={setSearchQuery} scrolled={scrolled} />
 
-      <div className="flex flex-auto w-full  max-w-[1200px] mx-auto px-4 md:px-8 gap-0 md:gap-7 overflow-hidden">
+      <div className="flex flex-auto w-full  max-w-[1200px] mx-auto px-4 md:px-8 gap-0 md:gap-7 md:overflow-hidden">
         {/* Left sidebar – aisles */}
         <aside className="hidden md:flex flex-col w-48 flex-shrink-0 overflow-y-auto py-6" style={{ marginRight: 28 }}>
           <AislesNav Categories={categories} showMyCart={false} handleFilter={selectFilter} activeFilter={filterOption} />
@@ -219,7 +228,7 @@ function App() {
         </aside>
 
         {/* Center – product list */}
-        <main ref={listRef} onScroll={handleListScroll} className="flex-1 min-w-0 overflow-y-auto pt-4 pb-24 md:py-8">
+        <main ref={listRef} onScroll={handleListScroll} className="flex-1 min-w-0 md:overflow-y-auto pt-4 pb-24 md:py-8">
           <div className={bounceClass} onAnimationEnd={() => setBounceClass('')}>
             {/* Week label + heading (desktop) */}
             <div className="mb-5 hidden md:block">

--- a/app/frontend/src/components/mobileAislesNav.jsx
+++ b/app/frontend/src/components/mobileAislesNav.jsx
@@ -1,35 +1,128 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 
-function MobileAislesNav({ categories, activeFilter, onSelect }) {
+function MobileAislesNav({ categories, activeFilter, onSelect, searchQuery, onSearch, scrolled }) {
+  const [isSearchMode, setIsSearchMode] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (isSearchMode && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isSearchMode]);
+
+  function openSearch() {
+    setIsSearchMode(true);
+    setInputValue('');
+    onSelect('📦 All Products');
+    onSearch('');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  function closeSearch() {
+    setIsSearchMode(false);
+    setInputValue('');
+    onSearch('');
+  }
+
+  function handleKeyDown(e) {
+    if (e.key === 'Escape') {
+      closeSearch();
+    }
+  }
+
+  // Shrink ~20% vertically when scrolled
+  const vPad = scrolled ? 6 : 10;
+  const iconSize = scrolled ? 28 : 34;
+  const chipPad = scrolled ? '5px 12px' : '7px 14px';
+  const chipFontSize = scrolled ? 12 : 13;
+
   return (
     <div
-      className="flex md:hidden bg-white border-b border-brand-border flex-shrink-0"
-      style={{ overflowX: 'auto', gap: '8px', padding: '10px 16px', scrollbarWidth: 'none' }}
+      className="flex md:hidden bg-white border-b border-brand-border flex-shrink-0 items-center sticky z-10"
+      style={{
+        padding: `${vPad}px 16px`,
+        gap: '8px',
+        top: scrolled ? 48 : 76,
+        transition: 'padding 0.3s, top 0.3s',
+      }}
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
     >
-      {categories.map((aisle) => {
-        const label = aisle.name.split(' ').slice(0, 2).join(' ');
-        const isActive = activeFilter === aisle.name;
-        return (
-          <button
-            key={aisle.id}
-            onClick={() => onSelect(aisle.name)}
-            style={{
-              whiteSpace: 'nowrap',
-              padding: '7px 14px',
-              borderRadius: '99px',
-              flexShrink: 0,
-              cursor: 'pointer',
-              fontSize: '13px',
-              fontWeight: 500,
-              border: isActive ? 'none' : '1.5px solid #E8E2DC',
-              background: isActive ? '#C4705E' : '#FDF7F5',
-              color: isActive ? '#fff' : '#8A3E2E',
-            }}
-          >
-            {label}
-          </button>
-        );
-      })}
+      {/* Magnifying glass — always first */}
+      <button
+        onClick={(e) => { e.stopPropagation(); isSearchMode ? closeSearch() : openSearch(); }}
+        aria-label={isSearchMode ? 'Close search' : 'Search products'}
+        style={{
+          flexShrink: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: iconSize,
+          height: iconSize,
+          borderRadius: '99px',
+          border: isSearchMode ? 'none' : '1.5px solid #E8E2DC',
+          background: isSearchMode ? '#C4705E' : '#FDF7F5',
+          cursor: 'pointer',
+          transition: 'width 0.3s, height 0.3s',
+        }}
+      >
+        {isSearchMode ? (
+          <span style={{ color: '#fff', fontSize: 16, lineHeight: 1 }}>×</span>
+        ) : (
+          <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="6.5" cy="6.5" r="5" stroke="#8A3E2E" strokeWidth="1.5"/>
+            <line x1="10.5" y1="10.5" x2="14" y2="14" stroke="#8A3E2E" strokeWidth="1.5" strokeLinecap="round"/>
+          </svg>
+        )}
+      </button>
+
+      {isSearchMode ? (
+        <input
+          ref={inputRef}
+          type="text"
+          value={inputValue}
+          onChange={e => { setInputValue(e.target.value); onSearch(e.target.value); }}
+          onKeyDown={handleKeyDown}
+          onClick={e => e.stopPropagation()}
+          placeholder="Search products…"
+          style={{
+            flex: 1,
+            border: 'none',
+            outline: 'none',
+            background: 'transparent',
+            fontSize: 14,
+            color: '#1A1514',
+          }}
+        />
+      ) : (
+        <div style={{ display: 'flex', overflowX: 'auto', gap: '8px', scrollbarWidth: 'none', flex: 1 }}>
+          {categories.map((aisle) => {
+            const label = aisle.name.split(' ').slice(0, 2).join(' ');
+            const isActive = activeFilter === aisle.name;
+            return (
+              <button
+                key={aisle.id}
+                onClick={(e) => { e.stopPropagation(); onSelect(aisle.name); }}
+                style={{
+                  whiteSpace: 'nowrap',
+                  padding: chipPad,
+                  borderRadius: '99px',
+                  flexShrink: 0,
+                  cursor: 'pointer',
+                  fontSize: chipFontSize,
+                  fontWeight: 500,
+                  border: isActive ? 'none' : '1.5px solid #E8E2DC',
+                  background: isActive ? '#C4705E' : '#FDF7F5',
+                  color: isActive ? '#fff' : '#8A3E2E',
+                  transition: 'padding 0.3s, font-size 0.3s',
+                }}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a magnifying glass icon as the first element in the mobile aisle nav; tapping it opens an inline text input that filters products reactively on each keystroke and clears the active aisle filter
- The mobile aisle nav is now sticky below the header; it shrinks ~20% vertically when scrolled and restores to full size when tapping the nav or scrolling back to the top

## Test plan
- [ ] Open on a mobile viewport (or Chrome DevTools mobile emulation)
- [ ] Confirm magnifying glass appears as the first chip in the aisle bar
- [ ] Tap it → chips disappear, input appears, aisle resets to All Products
- [ ] Type a product name → list filters reactively on each character
- [ ] Tap × → input clears, chips return, products reset
- [ ] Scroll down → nav sticks below the header and shrinks
- [ ] Tap the nav or scroll back to top → nav returns to full size
- [ ] Confirm desktop search bar and aisle nav are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)